### PR TITLE
Remove light font weight

### DIFF
--- a/gaia-tabs.js
+++ b/gaia-tabs.js
@@ -167,7 +167,6 @@ module.exports = component.register('gaia-tabs', {
 
       font-size: 17px;
       font-style: italic;
-      font-weight: lighter;
       background: none;
       cursor: pointer;
       color: inherit;


### PR DESCRIPTION
This came from a review from Amy Lee. She wants the font-weight to be normal (Fira Sans Regular) by default on gaia-tabs.